### PR TITLE
fix(seo): Replaces h1 tags with spans

### DIFF
--- a/src/components/consent-modal.js
+++ b/src/components/consent-modal.js
@@ -32,7 +32,7 @@ export default class ConsentModal extends React.Component {
                         </button>
                     }
 
-                    <h1 className={ns('Modal-title')} id="orejime-modal-title">{t(['consentModal', 'title'])}</h1>
+                    <span className={ns('Modal-title')} id="orejime-modal-title">{t(['consentModal', 'title'])}</span>
                     <p className={ns('Modal-description')}>
                         {manager.changed && (config.mustConsent || config.noNotice) &&
                             <p className={ns('Modal-description')}>

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -32,7 +32,7 @@ export default class ConsentNotice extends React.Component {
 
                 <div className={ns('Notice-text')}>
                     {title &&
-                        <h1 className={ns('Notice-title')} id="orejime-notice-title">{title}</h1>
+                        <span className={ns('Notice-title')} id="orejime-notice-title">{title}</span>
                     }
 
                     <p className={ns('Notice-description')}>


### PR DESCRIPTION
For SEO purposes.

h`x` tags should not be used.