### PR TITLE
Improved translations of the configure button

### DIFF
--- a/src/translations/ca.ts
+++ b/src/translations/ca.ts
@@ -10,9 +10,9 @@ export default {
 		accept: 'Acceptar',
 		acceptTitle: 'Acceptar les cookies',
 		decline: 'Refusar',
-		declineTitle: null,
-		configure: 'Més informació',
-		configureTitle: null
+		declineTitle: 'Rebutjar les galetes opcionals',
+		configure: 'Configurar',
+		configureTitle: 'Configurar cookies'
 	},
 	modal: {
 		title: 'La informació que recollim',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -10,9 +10,9 @@ export default {
 		accept: 'Akzeptieren',
 		acceptTitle: 'Cookies akzeptieren',
 		decline: 'Ablehnen',
-		declineTitle: 'optionalen Cookies ablehnen',
-		configure: 'Mehr erfahren',
-		configureTitle: 'Cookies auswählen'
+		declineTitle: 'Optionalen Cookies ablehnen',
+		configure: 'Konfigurieren',
+		configureTitle: 'Cookies konfigurieren'
 	},
 	modal: {
 		title: 'Informationen zur Privatsphäre',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Accept all cookies',
 		decline: 'Decline',
 		declineTitle: 'Decline optional cookies',
-		configure: 'Learn more',
-		configureTitle: 'Choose cookies'
+		configure: 'Configure',
+		configureTitle: 'Configure cookies'
 	},
 	modal: {
 		title: 'Information that we collect',

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Aceptar todas las cookies',
 		decline: 'Rechazar',
 		declineTitle: 'Rechazar todas las cookies opcionales',
-		configure: 'Más información',
-		configureTitle: 'Elegir cookies'
+		configure: 'Configurar',
+		configureTitle: 'Configurar las cookies'
 	},
 	modal: {
 		title: 'La información que recopilamos',

--- a/src/translations/et.ts
+++ b/src/translations/et.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Aktsepteeri kõik küpsised',
 		decline: 'Keeldu',
 		declineTitle: 'Keelata kõik valikulised küpsised',
-		configure: 'Lisateave',
-		configureTitle: 'Vali küpsised'
+		configure: 'Seadistada',
+		configureTitle: 'Seadistada küpsiseid'
 	},
 	modal: {
 		title: 'Isikuandmete kogumine',

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Hyväksy kaikki evästeet',
 		decline: 'Hylkää',
 		declineTitle: 'Hylkää kaikki valinnaiset evästeet',
-		configure: 'Lue lisää',
-		configureTitle: 'Valitse evästeet'
+		configure: 'Konfiguroida',
+		configureTitle: 'Määritä evästeet'
 	},
 	modal: {
 		title: 'Keräämämme tiedot',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Accepter tous les cookies',
 		decline: 'Refuser',
 		declineTitle: 'Refuser tous les cookies optionnels',
-		configure: 'En savoir plus',
-		configureTitle: 'Choisir les cookies'
+		configure: 'Configurer',
+		configureTitle: 'Configurer les cookies'
 	},
 	modal: {
 		title: 'Les informations que nous collectons',

--- a/src/translations/hu.ts
+++ b/src/translations/hu.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Minden cookie elfogadása',
 		decline: 'Elvet',
 		declineTitle: 'Minden opcionális cookie elutasítása',
-		configure: 'Tudj meg többet',
-		configureTitle: 'Cookie-k kiválasztása'
+		configure: 'Konfigurálni',
+		configureTitle: 'Konfigurálja a cookie-kat'
 	},
 	modal: {
 		title: 'Információk, amiket gyűjtünk',

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Accettare tutti i cookie',
 		decline: 'Rifiuta',
 		declineTitle: 'Rifiutare tutti i cookie opzionali',
-		configure: 'Scopri di più',
-		configureTitle: 'Scegliere i cookie'
+		configure: 'Configurare',
+		configureTitle: 'Configurare i cookie'
 	},
 	modal: {
 		title: 'Informazioni che raccogliamo',

--- a/src/translations/nb.ts
+++ b/src/translations/nb.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Godta alle informasjonskapsler',
 		decline: 'Avslå',
 		declineTitle: 'Avslå alle valgfrie informasjonskapsler',
-		configure: 'Lær mer',
-		configureTitle: 'Velg informasjonskapsler'
+		configure: 'Konfigurere',
+		configureTitle: 'Konfigurere informasjonskapsler'
 	},
 	modal: {
 		title: 'Informasjon vi samler inn',

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Alle cookies accepteren',
 		decline: 'Afwijzen',
 		declineTitle: 'Alle optionele cookies weigeren',
-		configure: 'Lees meer',
-		configureTitle: 'Cookies kiezen'
+		configure: 'Configureren',
+		configureTitle: 'Cookies configureren'
 	},
 	modal: {
 		title: 'Informatie die we verzamelen',

--- a/src/translations/oc.ts
+++ b/src/translations/oc.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Acceptar los cookies',
 		decline: 'Refusar',
 		declineTitle: 'Refusar los cookies',
-		configure: 'Ne saber mai',
-		configureTitle: null
+		configure: 'Configurar',
+		configureTitle: 'Configurar los cookies'
 	},
 	modal: {
 		title: 'Las informacions que reculhissèm',

--- a/src/translations/ro.ts
+++ b/src/translations/ro.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Acceptați toate modulele cookie',
 		decline: 'Renunță',
 		declineTitle: 'Refuzați toate modulele cookie opționale',
-		configure: 'Află mai multe',
-		configureTitle: 'Alegeți modulele cookie'
+		configure: 'Configurați',
+		configureTitle: 'Configura cookie'
 	},
 	modal: {
 		title: 'Informațiile pe care le colectăm',

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -11,8 +11,8 @@ export default {
 		acceptTitle: 'Acceptera alla cookies',
 		decline: 'Avböj',
 		declineTitle: 'Avvisa alla valfria cookies',
-		configure: 'Läs mer',
-		configureTitle: 'Välj cookies'
+		configure: 'Konfigurera',
+		configureTitle: 'Konfigurera cookies'
 	},
 	modal: {
 		title: 'Information som vi samlar',


### PR DESCRIPTION
They are now more descriptive of their action, and their title repeat their content, as required by the RGAA.