### PR TITLE
Nitpick: Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ var orejimeConfig = {
       description: 'Example of an inline tracking script',
       cookies: [
         'inline-tracker',
-	[
+        [
           // When deleting a cookie, Orejime will try to delete a cookie with the given name,
           // the "/" path, and multiple domains (the current domain and `"." + current domain`).
           // If an app sets a cookie on a different path or domain than that, Orejime won't be

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ var orejimeConfig = {
       title: 'Inline Tracker',
       description: 'Example of an inline tracking script',
       cookies: [
-        'inline-tracker'[
+        'inline-tracker',
+	[
           // When deleting a cookie, Orejime will try to delete a cookie with the given name,
           // the "/" path, and multiple domains (the current domain and `"." + current domain`).
           // If an app sets a cookie on a different path or domain than that, Orejime won't be


### PR DESCRIPTION
The purposes 🐬 -> cookies object for `Inline Tracker` has a missing comma.

Feel free to fix manually and not use my commit.