### PR TITLE
Remove non-existing file references from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,6 @@
     "low footprint",
     "lightweight"
   ],
-  "main": "./dist/orejime.js",
-  "browser": "./dist/orejime.js",
-  "exports": {
-    "./package.json": "./package.json",
-    "./orejime.js": "./dist/orejime.js",
-    "./orejime.css": "./dist/orejime.css"
-  },
   "scripts": {
     "start": "rspack --watch",
     "serve": "rspack serve",


### PR DESCRIPTION
Suppose you want to bundle the dist assets of `orejime` using Webpack:
```javascript
import "orejime/dist/orejime-standard.css";
import "orejime/dist/orejime-standard-de";
```
Webpack errors out with the following error message:
![grafik](https://github.com/user-attachments/assets/6a0110fa-f762-4fe2-84fb-ed976a3c8484)

I.e. Webpack complains, that it can't find the files from above, as these aren't exported from the NPM-package.
While having a deeper look into the `package.json` I've figured out, that the `main`-, `browser`- and `exports`-properties mostly reference files, which aren't even part of the dist-package.

That's why I simply removed the properties, which makes the Webpack bundling succeed! :)